### PR TITLE
Added block for public transport.

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -816,4 +816,12 @@ img::-moz-selection {
 body {
   webkit-tap-highlight-color: #222222;
 }
-
+#latetrain {
+	color: red;
+}
+#notlatetrain {
+	color: green;
+}
+#departureScheduled {
+	font-size:10px !important;
+}

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -192,6 +192,7 @@ function getBlock(cols,c,columndiv,standby){
 				}
 				else if(typeof(cols['blocks'][b]['trashapp'])!=='undefined') $(columndiv).append(loadTrash(random,cols['blocks'][b]));
 				else if(typeof(cols['blocks'][b]['frameurl'])!=='undefined') $(columndiv).append(loadFrame(random,cols['blocks'][b]));
+				else if(typeof(cols['blocks'][b]['station'])!=='undefined') $(columndiv).append(loadPublicTransport(random,cols['blocks'][b]));
 				else $(columndiv).append(loadButton(b,cols['blocks'][b]));
 			}
 			else {

--- a/js/main.js
+++ b/js/main.js
@@ -86,6 +86,7 @@ $.ajax({url: 'js/switches.js', async: false,dataType: "script"});
 $.ajax({url: 'js/trash.js', async: false,dataType: "script"});
 $.ajax({url: 'js/calendar.js', async: false,dataType: "script"});
 $.ajax({url: 'js/thermostat.js', async: false,dataType: "script"});
+$.ajax({url: 'js/publictransport.js', async: false,dataType: "script"});
 
 if(typeof(_DEBUG)!=='undefined' && _DEBUG){
 	$.ajax({url: 'custom/json_vb.js', async: false,dataType: "script"});

--- a/js/publictransport.js
+++ b/js/publictransport.js
@@ -1,0 +1,77 @@
+function loadPublicTransport(random,transportobject){
+	var width = 12;
+	if(typeof(transportobject.width)!=='undefined') width=transportobject.width;
+	var html='<div class="publictransport'+random+' col-xs-'+width+' transbg">';
+			html+='<div class="col-xs-2 col-icon">';
+				html+='<em class="fa fa-'+transportobject.icon+'"></em>';
+			html+='</div>';
+			html+='<div class="col-xs-10 col-data">';
+				html+='<span class="state"></span>';
+			html+='</div>';
+		html+='</div>';	
+	
+	//Get data every interval and call function to create block
+	setInterval(function(){
+		if(transportobject.provider == 'VVS'){
+			dataURL = 'https://efa-api.asw.io/api/v1/station/'+transportobject.station+'/departures/';
+		}
+		$.getJSON(dataURL,function(data){
+				dataPublicTransport(random,data,transportobject);
+		});
+	},(transportobject.interval * 1000));
+	return html;
+}
+
+
+function dataPublicTransport(random,data,transportobject){
+	$('.publictransport'+random+' .state').html('');
+	var dataPart = '';
+	var i = 0;
+	for(d in data){
+		if(transportobject.provider == 'VVS'){
+			delayMinutes = data[d]['delay'];
+			line = data[d]['number'];
+			direction = data[d]['direction'];
+			arrivalTime = addZero(data[d]['departureTime']['hour'])+':'+addZero(data[d]['departureTime']['minute']);
+			arrivalTimeScheduled = addMinutes(arrivalTime, delayMinutes*-1);
+		}
+		dataPart+='<div><b>'+arrivalTime+'</b> ';
+		//Check if there is live data available
+		if(typeof arrivalTimeScheduled != 'undefined'){
+			if(delayMinutes == 0){
+				latecolor='notlatetrain';
+			}	
+			else if(delayMinutes > 0){
+				latecolor='latetrain';
+			}
+			dataPart+='<span id="'+latecolor+'">+'+delayMinutes+' Min.</span> ';
+			dataPart+='<span id="departureScheduled">(Geplant: '+arrivalTimeScheduled+')</span> ';
+		}
+		dataPart+='- '+line+' '+direction+'</div>';
+		i = i+1;
+		if (i === transportobject.results) { break; }
+	}
+	
+	$('.publictransport'+random+' .state').append(dataPart)
+	
+	var dt = new Date();
+	$('.publictransport'+random+' .state').append(lang['last_update']+': '+addZero(dt.getHours()) + ":"+addZero(dt.getMinutes())+":"+addZero(dt.getSeconds()))
+}
+
+function addZero(input){
+	if(input < 10){
+		return '0' + input;
+	}
+	else{
+		return input;
+	}
+}
+function addMinutes(time/*"hh:mm"*/, minsToAdd/*"N"*/) {
+  function z(n){
+    return (n<10? '0':'') + n;
+  }
+  var bits = time.split(':');
+  var mins = bits[0]*60 + (+bits[1]) + (+minsToAdd);
+
+  return z(mins%(24*60)/60 | 0) + ':' + z(mins%60);  
+} 

--- a/lang/de_DE.js
+++ b/lang/de_DE.js
@@ -38,6 +38,7 @@ lang['temp_toon'] = 'Wohnzimmer';
 lang['wind'] = 'Wind';
 lang['select'] = 'Auswählen';
 lang['notifications_ns'] = 'Benachrichtigungen hinzugefügt von NS';
+lang['last_update'] = 'Zuletzt aktualisiert';
 
 lang['direction_N'] = 'nord'
 lang['direction_NNE'] = 'nord-nordost';

--- a/lang/en_US.js
+++ b/lang/en_US.js
@@ -38,6 +38,7 @@ lang['temp_toon'] = 'Living room';
 lang['wind'] = 'Wind';
 lang['select'] = 'Select';
 lang['notifications_ns'] = 'notifications added by NS';
+lang['last_update'] = 'Last update';
 
 lang['direction_N'] = 'north'
 lang['direction_NNE'] = 'north-northeast';

--- a/lang/fr_FR.js
+++ b/lang/fr_FR.js
@@ -38,6 +38,7 @@ lang['temp_toon'] = 'Température';
 lang['wind'] = 'Force';
 lang['select'] = 'Sélectionnez';
 lang['notifications_ns'] = 'messages postés par le NS';
+lang['last_update'] = 'Dernière mise à jour';
 
 lang['direction_N'] = 'north'
 lang['direction_NNE'] = 'north-northeast';

--- a/lang/hu_HU.js
+++ b/lang/hu_HU.js
@@ -37,6 +37,7 @@ lang['temp_toon'] = 'Nappali';
 lang['wind'] = 'Szél';
 lang['select'] = 'Kiválaszt';
 lang['notifications_ns'] = 'notifications added by NS';
+lang['last_update'] = 'Utolsó frissítés';
 
 lang['direction_N'] = 'észak'
 lang['direction_NNE'] = 'észak-északkelet';

--- a/lang/it_IT.js
+++ b/lang/it_IT.js
@@ -38,6 +38,7 @@ lang['temp_toon'] = 'Salone';
 lang['wind'] = 'Vento';
 lang['select'] = 'Seleziona';
 lang['notifications_ns'] = 'notifica aggiunta da NS';
+lang['last_update'] = 'Ultimo aggiornamento';
 
 lang['direction_N'] = 'nord'
 lang['direction_NNE'] = 'nord-nordest';

--- a/lang/nl_NL.js
+++ b/lang/nl_NL.js
@@ -38,6 +38,7 @@ lang['temp_toon'] = 'Woonkamer';
 lang['wind'] = 'Kracht';
 lang['select'] = 'Selecteer';
 lang['notifications_ns'] = 'meldingen geplaatst door de NS';
+lang['last_update'] = 'Laatste update';
 
 lang['direction_N'] = 'noord'
 lang['direction_NNE'] = 'noord-noordoost';

--- a/lang/pt_PT.js
+++ b/lang/pt_PT.js
@@ -37,6 +37,7 @@ lang['temp_toon'] = 'Sala de estar';
 lang['wind'] = 'Vento';
 lang['select'] = 'Selecionar';
 lang['notifications_ns'] = 'notifica&ccedil&otilde;es adicionada por NS';
+lang['last_update'] = 'Última atualização';
 
 lang['direction_N'] = 'norte'
 lang['direction_NNE'] = 'norte-nordeste';

--- a/lang/sv_SE.js
+++ b/lang/sv_SE.js
@@ -37,6 +37,7 @@ lang['temp_toon'] = 'Vardagsrum';
 lang['wind'] = 'Vind';
 lang['select'] = 'Välj';
 lang['notifications_ns'] = 'avviseringar från NS';
+lang['last_update'] = 'Senaste uppdateringen';
 
 lang['direction_N'] = 'nord'
 lang['direction_NNE'] = 'nord-nordost';


### PR DESCRIPTION
Created a block for public transport.
Currently the whole area of VVS is supported with live data from https://efa-api.asw.io.
This is in fact Stuttgart, Germany and a big part around this place.
To call the function properly, you will need the correct station id from: https://efa-api.asw.io/api/v1/station/

So for Stuttgart Central Station the data will come from https://efa-api.asw.io/api/v1/station/5006118/departures/

Then the data will be collected and shown with possible delays.
If created it mostly customizable so a typical call from config.js looks like this:
var publictransport = {}
publictransport.hbf= { station: '5006118', provider: 'VVS', icon: 'train', interval: 15, results: 5 };

icon is simply font-awesome without fa, interval = time in seconds for refreshing the data, and results = number of shown results. Also possible is to customize the width, but i would not change the value of 12 because of the size of the output.