### PR TITLE
Add support for excluding specific garbage pickups

### DIFF
--- a/js/garbage.js
+++ b/js/garbage.js
@@ -332,6 +332,7 @@ function getTrashRow(c,d,orgcolor){
 	if(typeof(trashcolors)!=='undefined' && typeof(trashcolors[c])!=='undefined') color=' style="color:'+trashcolors[c]+'"';
 	if(typeof(trashnames)!=='undefined' && typeof(trashnames[c])!=='undefined') c = trashnames[c];
 	
+	if (c.length == 0) return '';
 	if(c.substr(0,7)=='Bo zl12'){
 		if(c.toLowerCase().indexOf("gft")>0) c='GFT';
 		else if(c.toLowerCase().indexOf("rest")>0) c='Restafval';
@@ -348,6 +349,7 @@ function addToContainer(random,returnDates,maxitems){
 	var done = {};
 	for(c in returnDates){
 		for(cr in returnDates[c]){
+			if (returnDates[c][cr] == '') continue;
 			returnDatesSimple[cr] = returnDates[c][cr];
 			done[c]=true;
 		}


### PR DESCRIPTION
I added a patch that allows the user to provide an empty `trashnames` value in order to hide the specific garbage type like so:

```js
var trashnames = {}
trashnames['Gft'] = 'GFT';
trashnames['Plastic, metaal en drankenkartons'] = 'Plastic';
trashnames['Kca'] = '';
```

With this patch the `Kca` entry will never show on the dashboard and not count towards `garbage_maxitems`

I did consider adding a new `trashhidden` global but I thought an empty trashname == hidden is logical enough.