### PR TITLE
Added a chromecast plugin to cast a stream directly to a Chromecast

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -773,6 +773,10 @@ p {
 	cursor:pointer;
 }
 
+.cast-button {
+	padding: 3px !important;
+}
+
 	.col-xs-1,
 	.col-xs-2,
 	.col-xs-3,

--- a/css/creative.css
+++ b/css/creative.css
@@ -773,8 +773,17 @@ p {
 	cursor:pointer;
 }
 
-.cast-button {
+.cast-button-container {
 	padding: 3px !important;
+}
+.cast-button {
+	height: 25px;
+	width: 25px;
+	padding: 1px;
+	vertical-align: middle;
+	display: inline;
+	--disconnected-color: red;
+	--connected-color: green;
 }
 
 	.col-xs-1,

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -229,6 +229,10 @@ function getBlock(cols,c,columndiv,standby){
 
 				addStreamPlayer('.containsstreamplayer'+random);					
 			}
+			else if(cols['blocks'][b] == 'chromecast') {
+				$.ajax({url: 'js/chromecast.js', async: false,dataType: "script"});
+				loadChromecast(columndiv);
+			}
 			else if(cols['blocks'][b]=='garbage'){
 				if(typeof(loadGarbage)!=='function') $.ajax({url: 'js/garbage.js', async: false,dataType: "script"});
 				

--- a/js/chromecast.js
+++ b/js/chromecast.js
@@ -10,16 +10,22 @@ function loadChromecast(columndiv) {
     var random = getRandomInt(1, 100000);
     var html = '<div data-id="chromecast" class="transbg containschromecast' + random + '">';
     html += '<div class="col-xs-12 transbg smalltitle"><h3></h3></div>';
-    html += '<div class="col-xs-4 transbg hover text-center btnPrev">';
-    html += '<em class="fa fa-chevron-left fa-small"></em>';
+    html += '<div class="col-xs-2 transbg hover text-center btnPrev">';
+    html += '   <em class="fa fa-chevron-left fa-small"></em>';
     html += '</div>';
-    html += '<div class="col-xs-4 transbg hover text-center cast-button">';
+    html += '<div class="col-xs-2 transbg hover text-center btnNext">';
+    html += '   <em class="fa fa-chevron-right fa-small"></em>';
+    html += '</div>';
+    html += '<div class="col-xs-4 transbg hover text-center cast-button-container">';
     html += '<div class="col-xs-4 col-xs-push-4">';
-    html += '<button style="height: 25px; width: 25px; padding: 1px; vertical-align: middle; display: inline; --disconnected-color: red; --connected-color: green" is="google-cast-button"></button>';
+    html += '   <button class="cast-button" is="google-cast-button"></button>';
     html += '</div>';
     html += '</div>';
-    html += '<div class="col-xs-4 transbg hover text-center btnNext">';
-    html += '<em class="fa fa-chevron-right fa-small"></em>';
+    html += '<div class="col-xs-2 transbg hover text-center btnVolDown">';
+    html += '   <em class="fa fa-volume-down fa-small"></em>';
+    html += '</div>';
+    html += '<div class="col-xs-2 transbg hover text-center btnVolUp">';
+    html += '   <em class="fa fa-volume-up fa-small"></em>';
     html += '</div>';
     html += '</div>';
     $(columndiv).append(html);
@@ -72,6 +78,19 @@ function loadStream(currentMediaURL) {
     }
 }
 
+function changeVolume(action) {
+    var castSession = cast.framework.CastContext.getInstance().getCurrentSession();
+    if (castSession !== null) {
+        var volume = castSession.getVolume();
+        log('Volume: ' + volume);
+        if (action === 'up') {
+            castSession.setVolume(volume + 0.02);
+        } else {
+            castSession.setVolume(volume - 0.02);
+        }
+    }
+}
+
 function selectStream(streamelement) {
     var trackCount = _STREAMPLAYER_TRACKS.length,
         titleElement = $(streamelement + ' h3');
@@ -89,6 +108,12 @@ function selectStream(streamelement) {
         }
 
         loadTrack(selectedStreamIndex);
+    });
+    $(streamelement + ' .btnVolDown').click(function() {
+        changeVolume('down');
+    });
+    $(streamelement + ' .btnVolUp').click(function() {
+        changeVolume('up');
     });
     var loadTrack = function(id) {
         titleElement.text(_STREAMPLAYER_TRACKS[id].name);

--- a/js/chromecast.js
+++ b/js/chromecast.js
@@ -1,0 +1,108 @@
+/**
+ * The selected stream
+ * @type {number}
+ */
+var selectedStreamIndex = 0;
+
+function loadChromecast(columndiv) {
+    head.load("https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1");
+
+    var random = getRandomInt(1, 100000);
+    var html = '<div data-id="chromecast" class="transbg containschromecast' + random + '">';
+    html += '<div class="col-xs-12 transbg smalltitle"><h3></h3></div>';
+    html += '<div class="col-xs-4 transbg hover text-center btnPrev">';
+    html += '<em class="fa fa-chevron-left fa-small"></em>';
+    html += '</div>';
+    html += '<div class="col-xs-4 transbg hover text-center cast-button">';
+    html += '<div class="col-xs-4 col-xs-push-4">';
+    html += '<button style="height: 25px; width: 25px; padding: 1px; vertical-align: middle; display: inline; --disconnected-color: red; --connected-color: green" is="google-cast-button"></button>';
+    html += '</div>';
+    html += '</div>';
+    html += '<div class="col-xs-4 transbg hover text-center btnNext">';
+    html += '<em class="fa fa-chevron-right fa-small"></em>';
+    html += '</div>';
+    html += '</div>';
+    $(columndiv).append(html);
+
+    window['__onGCastApiAvailable'] = function(isAvailable) {
+        if (isAvailable) {
+            cast.framework.CastContext.getInstance().setOptions({
+                receiverApplicationId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
+                autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED
+            });
+
+            var context = cast.framework.CastContext.getInstance();
+            context.addEventListener(
+                cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
+                function(event) {
+                    switch (event.sessionState) {
+                        case cast.framework.SessionState.SESSION_STARTED:
+                            log('CastContext: CastSession started');
+                            loadStream(_STREAMPLAYER_TRACKS[selectedStreamIndex].file);
+
+                            break;
+                        case cast.framework.SessionState.SESSION_RESUMED:
+                            log('CastContext: CastSession resumed');
+                            break;
+                        case cast.framework.SessionState.SESSION_ENDED:
+                            log('CastContext: CastSession disconnected');
+                            // Update locally as necessary
+                            break;
+                    }
+                })
+            selectStream('.containschromecast' + random);
+        }
+    };
+}
+
+function loadStream(currentMediaURL) {
+    var contentType = 'audio/mp3';
+    var castSession = cast.framework.CastContext.getInstance().getCurrentSession();
+    var mediaInfo = new chrome.cast.media.MediaInfo(currentMediaURL, contentType);
+    var request = new chrome.cast.media.LoadRequest(mediaInfo);
+
+    if (castSession !== null) {
+        castSession.loadMedia(request).then(
+            function () {
+                log('Load succeed: ' + currentMediaURL);
+            },
+            function (errorCode) {
+                log('Error code: ' + errorCode);
+            });
+    }
+}
+
+function selectStream(streamelement) {
+    var trackCount = _STREAMPLAYER_TRACKS.length,
+        titleElement = $(streamelement + ' h3');
+    $(streamelement + ' .btnPrev').click(function() {
+        selectedStreamIndex--;
+        if (selectedStreamIndex < 0) {
+            selectedStreamIndex = trackCount - 1;
+        }
+        loadTrack(selectedStreamIndex);
+    });
+    $(streamelement + ' .btnNext').click(function() {
+        selectedStreamIndex++;
+        if (selectedStreamIndex === trackCount) {
+            selectedStreamIndex = 0;
+        }
+
+        loadTrack(selectedStreamIndex);
+    });
+    var loadTrack = function(id) {
+        titleElement.text(_STREAMPLAYER_TRACKS[id].name);
+        loadStream(_STREAMPLAYER_TRACKS[id].file);
+    };
+    loadTrack(selectedStreamIndex);
+}
+
+/**
+ * Simple log function to log to the console if debug is true (set this in CONFIG.js)
+ * @param message
+ */
+function log(message) {
+    if (config['debug']) {
+        console.log(message);
+    }
+}


### PR DESCRIPTION
This plugin gives the option to add a block with a chromecast button and some player buttons. It is highly inspired by the streamplayer that is already integrated (it uses even the same streams from the config).

The play button is changed to the default cast button from google. When clicking on it, the default casting screen from chrome pops up, where you can select the available chromecasts in your network. The arrows on the left let you select the streams, on the right side the volume buttons are available.

The block is available as 'chromecast' in the config, for example
`columns[3]['blocks'] = ['chromecast'];`