### PR TITLE
Fix for IE11

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -394,17 +394,17 @@ function getStatusBlock(idx,device,block,c){
         });
     }
 
-	for(d of elements) {
-	    deviceValue = device[d];
+	for(d in elements) {
+	    deviceValue = device[elements[d]];
 	    if (block.hasOwnProperty('format') && block.format) {
 	        unit = '';
-	        if (isNaN(device[d])) {
-	            unit = ' ' + device[d].split(' ')[1];
+	        if (isNaN(device[elements[d]])) {
+	            unit = ' ' + device[elements[d]].split(' ')[1];
             }
             deviceValue = number_format(deviceValue, block.decimals) + unit;
         }
-		value = value.replace('<'+d+'>', deviceValue);
-		title = title.replace('<'+d+'>', device[d]);
+		value = value.replace('<' + elements[d] + '>', deviceValue);
+		title = title.replace('<' + elements[d] + '>', device[elements[d]]);
 	}
 	
 	if(typeof(blocks[idx])!=='undefined' && typeof(blocks[idx]['unit'])!=='undefined'){

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -474,6 +474,9 @@ function getBlockClick(idx,device){
 			}
 		}
 	}
+	else if (typeof(blocks[idx]) !== 'undefined' && typeof(blocks[idx]['graph']) !== 'undefined' && blocks[idx]['graph'] === false) {
+		return;
+    }
 	else if(typeof(device)!=='undefined'){
 		if (device['SubType']=='Percentage' || device['SubType']=='Custom Sensor' || device['TypeImg']=='counter'
             || device['Type']=='Temp' || device['Type']=='Wind' || device['Type']=='Rain'

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -53,8 +53,6 @@ function getGraphs(device,popup){
             txtUnit = "m3";
             break;
         case 'Energy':
-            txtUnit = "kWh";
-            break;
         case 'kWh':
         case 'YouLess counter':
             txtUnit = "kWh";
@@ -311,6 +309,9 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
                                 xkey: currentdate,
                                 ykey: parseFloat(data.result[r]['v2'])+parseFloat(data.result[r]['v'])
                             };
+                            if (label === 'kWh' && realrange === 'day') {
+                                labels = ['Watt'];
+                            }
                         }
                         else if(typeof(data.result[r]['v'])!=='undefined'){
                             if (data.method === 1) {
@@ -320,8 +321,8 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
                                 xkey: currentdate,
                                 ykey: data.result[r]['v']
                             };
-                            if (label === 'kWh' && typeof(data.result[r]['c']) === 'undefined') {
-                                labels = ['Wh'];
+                            if (label === 'kWh' && realrange === 'day') {
+                                labels = ['Watt'];
                             }
                         }
                         else if(typeof(data.result[r]['eu'])!=='undefined'){

--- a/js/main.js
+++ b/js/main.js
@@ -1145,7 +1145,7 @@ function getDevices(override){
 											var icon = 'fa-plug';
 											if(typeof(blocks[idx+'_5'])!=='undefined' && typeof(blocks[idx+'_5']['icon'])!=='undefined') icon=blocks[idx+'_5']['icon'];
                                             device['CounterDelivToday'] = device['CounterDelivToday'].split(' ')[0];
-                                            html = getStateBlock(idx+'_2',icon,title,number_format(device['CounterDelivToday'], settings['units'].decimals.kwh) + ' ' + settings['units'].names.kwh,device);
+                                            html = getStateBlock(idx+'_5',icon,title,number_format(device['CounterDelivToday'], settings['units'].decimals.kwh) + ' ' + settings['units'].names.kwh,device);
 											if(typeof(allblocks[idx])!=='undefined' && $('div.block_'+idx+'_5').length==0) var duplicate = $('div.block_'+idx+'_4').last().clone().removeClass('block_'+idx+'_4').addClass('block_'+idx+'_5').insertAfter($('div.block_'+idx+'_4'));
 											$('div.block_'+idx+'_5').html(html);
 											addHTML=false;


### PR DESCRIPTION
It looks like IE11 does not support the newer version of javascript that was needed for the `for(d of elements) {` functionality. Reverted it back to `for(d in elements) {`

This PR also fixes an issue with a `'_5'` block not having a popup (smart meter graph). 

On top of that, an option is added to disable the graph popup on a block (handy if you already have the graph somewhere else on the screen.
It works with:
`blocks['35_1']['graph'] = false;`