### PR TITLE
Better handling of Custom Sensors in graphs

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -41,8 +41,8 @@ blocktypes.Name['Regen verwacht'] = { icon: 'fa fa-tint', title: '<Data>', value
 blocktypes.Name['Regen Verwacht'] = { icon: 'fa fa-tint', title: '<Data>', value: '<Name>' }
 
 blocktypes.Name['Ping'] = { icon: 'fa fa-arrows-v', title: '<Name>', value: '<Data>' }
-blocktypes.Name['Upload'] = { icon: 'fa fa-upload', title: '<Name>', value: '<Data>' }
-blocktypes.Name['Download'] = { icon: 'fa fa-download', title: '<Name>', value: '<Data>' }
+blocktypes.Name['Upload'] = { icon: 'fa fa-upload', title: '<Name>', value: '<Data>', format: true, decimals: 3 }
+blocktypes.Name['Download'] = { icon: 'fa fa-download', title: '<Name>', value: '<Data>', format: true, decimals: 3 }
 
 blocktypes.Name['Maanfase'] = { icon: 'fa fa-moon-o', title: '<Data>', value: '<Name>' }
 blocktypes.Name['Moon phase'] = { icon: 'fa fa-moon-o', title: '<Data>', value: '<Name>' }

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -139,9 +139,7 @@ function getButtonGraphs(device){
 	}
 }
 
-function showGraph(idx,title,label,range,current,forced,sensor,popup){
-	graphColor = '#eee';
-	graphColor2 = '#eee';
+function showGraph(idx, title, label, range, current, forced, sensor, popup) {
 	if(typeof(popup)=='undefined') forced=false;
 	if(typeof(forced)=='undefined') forced=false;
 	
@@ -176,6 +174,10 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
 			url: settings['domoticz_ip']+'/json.htm?type=graph&sensor='+sensor+'&idx='+idx+'&range='+realrange+'&time='+new Date().getTime()+'&jsoncallback=?',
 			type: 'GET',async: true,contentType: "application/json",dataType: 'jsonp',
 			success: function(data) {
+                if(data.status=="ERR") {
+                    alert('Could not load graph!');
+                    return;
+                }
 				var orgtitle = title;
 				title = '<h4>'+title;
 				if(typeof(current)!=='undefined' && current!=='undefined') title+=': <B class="graphcurrent'+idx+'">' + current + ' ' + label + '</B>';
@@ -203,10 +205,6 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
 					html+='</div>';
 				html+='</div>';
 				
-				if(data.status=="ERR") {
-                    alert('Could not load graph!');
-                    return;
-                }
                 if($('#graph'+idx+'.graph').length>0){
                     $('#graph'+idx+'.graph').replaceWith(html);
                 }
@@ -216,7 +214,6 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
                 var data_com=new Array();
                 var labels = [label];
                 var ykeys = ['ykey'];
-                var lineColors = [graphColor, graphColor2, graphColor2];
                 var count=0;
                 for (r in data.result) {
                     var currentdate = moment(data.result[r].d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']);
@@ -371,7 +368,7 @@ function showGraph(idx,title,label,range,current,forced,sensor,popup){
                         xkey: ['xkey'],
                         ykeys: ykeys,
                         labels: labels,
-                        lineColors: lineColors,
+                        lineColors: settings['lineColors'],
                         pointFillColors: ['none'],
                         pointSize: 3,
                         hideHover: 'auto',

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -44,9 +44,13 @@ function getGraphs(device,popup){
 
     switch (device['SubType']) {
         case 'Percentage':
-        case 'Custom Sensor':
             sensor = 'Percentage';
             txtUnit = '%';
+            decimals = 1;
+            break;
+        case 'Custom Sensor':
+            sensor = 'Percentage';
+            txtUnit = device['SensorUnit'];
             decimals = 1;
             break;
         case 'Gas':

--- a/js/settings.js
+++ b/js/settings.js
@@ -413,6 +413,7 @@ if(typeof(settings['units']) === 'undefined') {
         }
     };
 }
+if(typeof(settings['lineColors']) === 'undefined') settings['lineColors'] = ['#eee', '#eee', '#eee'];
 
 var _TEMP_SYMBOL = '°C';
 if(settings['use_fahrenheit']==1) _TEMP_SYMBOL = '°F';


### PR DESCRIPTION
Instead of always showing the '%' as unit, now the sensor unit itself is used.

Also graphline colors can be changed in config now, i.e.:
`config['lineColors'] = ['#e00', '#0e0', '#00e'];`
First step to #10 