### PR TITLE
Using room plan for getting devices

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -945,7 +945,7 @@ function getDevices(override) {
         gettingDevices = true;
 
         req = $.getJSONP({
-            url: settings['domoticz_ip'] + '/json.htm?type=devices&filter=all&used=true&order=Name&jsoncallback=?',
+            url: settings['domoticz_ip'] + '/json.htm?type=devices&plan=' + settings['room_plan'] + '&filter=all&used=true&order=Name&jsoncallback=?',
             type: 'GET', async: true, contentType: "application/json", dataType: 'jsonp',
             error: function (jqXHR, textStatus) {
                 console.error("Domoticz error!\nPlease, double check the path to Domoticz in Settings!");

--- a/js/settings.js
+++ b/js/settings.js
@@ -433,6 +433,7 @@ if (typeof(settings['garbage_use_names']) === 'undefined') settings['garbage_use
 if (typeof(settings['garbage_use_colors']) === 'undefined') settings['garbage_use_colors'] = false;
 if (typeof(settings['garbage_icon_use_colors']) === 'undefined') settings['garbage_icon_use_colors'] = true;
 if (typeof(settings['lineColors']) === 'undefined') settings['lineColors'] = ['#eee', '#eee', '#eee'];
+if (typeof(settings['room_plan']) === 'undefined') settings['room_plan'] = 0;
 
 var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';


### PR DESCRIPTION
Defaults to 0, which is just all devices like before.

In Domoticz it is necessary to create a room plan with the device you need in Dashticz. The number of the room plan can be given in the config of Dashticz, so only those devices will be fetched. This can speed up loading a lot (My request to domoticz is abount 1 second faster now (from 1.2s to ~220ms)

New config parameter example:
`config['room_plan'] = 2; // Where 2 is the room plan id` 