### PR TITLE
Add garbage settings to menu

### DIFF
--- a/js/garbage.js
+++ b/js/garbage.js
@@ -265,7 +265,7 @@ function addToContainer(random, returnDates) {
     returnDates = filterReturnDates(returnDates);
     $('.trash' + random + ' .state').html('');
 
-    if (settings['garbage_icon_use_colors'] === true) {
+    if (settings['garbage_icon_use_colors']) {
         $('.trash' + random).find('img.trashcan').attr('src', settings['garbage'][returnDates[0].garbageType]['icon']);
         $('.trash' + random).find('img.trashcan').css('opacity', '0.7');
     } else {

--- a/js/settings.js
+++ b/js/settings.js
@@ -5,6 +5,7 @@ settingList['general']['title'] = language.settings.general.title;
 settingList['general']['domoticz_ip'] = {};
 settingList['general']['domoticz_ip']['title'] = language.settings.general.domoticz_ip;
 settingList['general']['domoticz_ip']['type'] = 'text';
+settingList['general']['domoticz_ip']['help'] = language.settings.general.domoticz_ip_help;
 
 settingList['general']['app_title'] = {};
 settingList['general']['app_title']['title'] = language.settings.general.app_title;

--- a/js/settings.js
+++ b/js/settings.js
@@ -358,6 +358,23 @@ settingList['garbage']['garbage_hideicon'] = {};
 settingList['garbage']['garbage_hideicon']['title'] = language.settings.garbage.garbage_hideicon;
 settingList['garbage']['garbage_hideicon']['type'] = 'checkbox';
 
+settingList['garbage']['garbage_icon_use_colors'] = {};
+settingList['garbage']['garbage_icon_use_colors']['title'] = language.settings.garbage.garbage_icon_use_colors;
+settingList['garbage']['garbage_icon_use_colors']['type'] = 'checkbox';
+
+settingList['garbage']['garbage_use_colors'] = {};
+settingList['garbage']['garbage_use_colors']['title'] = language.settings.garbage.garbage_use_colors;
+settingList['garbage']['garbage_use_colors']['type'] = 'checkbox';
+
+settingList['garbage']['garbage_use_names'] = {};
+settingList['garbage']['garbage_use_names']['title'] = language.settings.garbage.garbage_use_names;
+settingList['garbage']['garbage_use_names']['type'] = 'checkbox';
+
+settingList['garbage']['garbage_use_cors_prefix'] = {};
+settingList['garbage']['garbage_use_cors_prefix']['title'] = language.settings.garbage.garbage_use_cors_prefix;
+settingList['garbage']['garbage_use_cors_prefix']['type'] = 'checkbox';
+settingList['garbage']['garbage_use_cors_prefix']['help'] = language.settings.garbage.garbage_use_prefix_help;
+
 settingList['about'] = {};
 settingList['about']['title'] = language.settings.about.title;
 
@@ -448,12 +465,13 @@ if (typeof(settings['garbage']) === 'undefined') {
         milieu: {kliko: 'yellow', code: '#f9e231', name: 'Geel', icon: 'img/kliko_yellow.png'},
     };
 }
-if (typeof(settings['garbage_use_names']) === 'undefined') settings['garbage_use_names'] = false;
-if (typeof(settings['garbage_use_colors']) === 'undefined') settings['garbage_use_colors'] = false;
-if (typeof(settings['garbage_icon_use_colors']) === 'undefined') settings['garbage_icon_use_colors'] = true;
-if (typeof(settings['garbage_use_cors_prefix']) === 'undefined') settings['garbage_use_cors_prefix'] = true;
+if (typeof(settings['garbage_use_names']) === 'undefined') settings['garbage_use_names'] = 0;
+if (typeof(settings['garbage_use_colors']) === 'undefined') settings['garbage_use_colors'] = 0;
+if (typeof(settings['garbage_icon_use_colors']) === 'undefined') settings['garbage_icon_use_colors'] = 1;
+if (typeof(settings['garbage_use_cors_prefix']) === 'undefined') settings['garbage_use_cors_prefix'] = 1;
 if (typeof(settings['lineColors']) === 'undefined') settings['lineColors'] = ['#eee', '#eee', '#eee'];
 if (typeof(settings['room_plan']) === 'undefined') settings['room_plan'] = 0;
+if (typeof(settings['garbage_use_cors_prefix']) === 'undefined') settings['garbage_use_cors_prefix'] = 1;
 
 var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';


### PR DESCRIPTION
Add these strings to language files:

"garbage_icon_use_colors": "Colors on Icon",
"garbage_use_colors": "Text Colors",
"garbage_use_names": "Custom Names",
"garbage_use_cors_prefix": "Use Cors Prefix (Default is on)",
"garbage_use_prefix_help": "The cors prefix sometimes causes errors in IE."
"domoticz_ip_help": "Enter Domoticz url, for example: http: \ / \ / 192.168.1.1:8080. You can also enter users and password, for example: http: \ / \ / user:password@192.168.1.1: 8080"