### PR TITLE
Fix for Forecast.io refresh in a frame

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -833,13 +833,15 @@ function reloadFrame(i, frame) {
 
     if (typeof(frame.frameurl) !== 'undefined') {
         var img = frame.frameurl;
-        if (img.indexOf("?") != -1) var sep = '&';
+        if(img.indexOf("forecast.io")==-1) {
+            if (img.indexOf("?") != -1) var sep = '&';
 
-        if (img.indexOf("?") != -1) {
-            var newimg = img.split(sep + 't=');
-            img = newimg;
+            if (img.indexOf("?") != -1) {
+                var newimg = img.split(sep + 't=');
+                img = newimg;
+            }
+            img += sep + 't=' + (new Date()).getTime();
         }
-        img += sep + 't=' + (new Date()).getTime();
     }
 
     $('.imgblock' + i).find('iframe').attr('src', img);


### PR DESCRIPTION
If forecast.io is being used in an iFrame then after a reload the colors might change.
Dashticz adds '&t=...' to the URL to prevent caching. The resulting URL is not interpreted correctly by forecast.io.

To prevent this, the '&t=...' is not added anymore when the url contains forecast.io.

Forecast.io has its own mechanism to handle caching. The '&t=...' trick doesn't work. I noticed that the max cache time for a location in the Netherlands is 3600 seconds (1 hour). For a location in Canada it is 60 seconds.