### PR TITLE
Addition of PHP based CORS proxy

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -247,7 +247,7 @@ function handleStringBlock(block, columndiv, width, c) {
             return;
 		case 'longfonds':
 			$(columndiv).append('<div data-id="longfonds" class="mh transbg block_longfonds col-xs-'+width+'"></div>');
-			$.getJSON(settings['default_cors_url'] + 'https://www.longfonds.nl/gezondelucht/api/zipcode-check?zipcode='+settings['longfonds_zipcode']+'&houseNumber='+settings['longfonds_housenumber'],function(data){
+			$.getJSON(_CORS_PATH + 'https://www.longfonds.nl/gezondelucht/api/zipcode-check?zipcode='+settings['longfonds_zipcode']+'&houseNumber='+settings['longfonds_housenumber'],function(data){
 				var stateBlock = '<div class="col-xs-4 col-icon">';
 				stateBlock += '<em class="fas fa-cloud"></em>';
 				stateBlock += '</div>';

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,6 +1,11 @@
 var recurring = {};
 
 function addCalendar(calobject, icsUrlorg) {
+  if(!_PHP_INSTALLED) {
+    console.error("Domoticz error!\nCalendar requires a PHP enabled web server.");
+    infoMessage('<font color="red">Domoticz error!', 'Calendar requires a PHP enabled web server</font>', 0);
+    return;
+  }
     if (typeof(icsUrlorg.calendars) == 'undefined') {
         var icsUrl = {};
         icsUrl.calendars = [];

--- a/js/coins.js
+++ b/js/coins.js
@@ -12,7 +12,7 @@ function getCoin(coin) {
 }
 
 function appendLiteBit(coin) {
-    $.getJSON(settings['default_cors_url'] + 'https://www.litebit.eu/system/live-updates', function (data) {
+    $.getJSON(_CORS_PATH + 'https://www.litebit.eu/system/live-updates', function (data) {
 
         var symbol = '€';
         var varname = coin['key'] + 'RateBuyRound';

--- a/js/garbage.js
+++ b/js/garbage.js
@@ -28,7 +28,7 @@ function loadGarbage() {
 
 function getPrefixUrl() {
     if (settings['garbage_use_cors_prefix']) {
-        return settings['default_cors_url'];
+        return _CORS_PATH;
     }
     return '';
 }
@@ -215,6 +215,11 @@ function getAfvalwijzerArnhemData(address, date, random) {
 }
 
 function getGeneralData(service,address, date, random, subservice){
+  if(!_PHP_INSTALLED) {
+    console.error("Domoticz error!\nGarbage requires a PHP enabled web server.");
+    infoMessage('<font color="red">Domoticz error!', 'Garbage requires a PHP enabled web server</font>', 0);
+    return;
+  }
   var cURI = settings['dashticz_php_path']+'garbage/?service='+service+'&sub='+subservice+'&zipcode=' + address.zipcode + '&nr=' + address.housenumber + '&t=' + address.housenumberSuffix;
 	$.getJSON(cURI, function (data) {
 		 data = data

--- a/js/news.js
+++ b/js/news.js
@@ -8,7 +8,7 @@ function getNews(divToFill, newsfeed) {
     if (typeof(settings['default_news_url']) !== 'undefined') {
         // Some RSS feed doesn't load trough crossorigin.me or vice versa
         //$.ajax('https://crossorigin.me/'+newsfeed, {
-        $.ajax(newsfeed, {
+        $.ajax(_CORS_PATH + newsfeed, {
             accepts: {
                 xml: 'application/rss+xml'
             },

--- a/js/ns.js
+++ b/js/ns.js
@@ -1,5 +1,5 @@
 function getTrainInfo() {
-    var rssurl = settings['default_cors_url'] + 'https://www.rijdendetreinen.nl/rss/';
+    var rssurl = _CORS_PATH + 'https://www.rijdendetreinen.nl/rss/';
 
     $.ajax(rssurl, {
         accepts: {

--- a/js/publictransport.js
+++ b/js/publictransport.js
@@ -48,10 +48,10 @@ function getData(random,transportobject){
 		dataURL = 'https://efa-api.asw.io/api/v1/station/'+transportobject.station+'/departures/';
 	}
 	else if(provider == 'mobiliteit'){
-		dataURL = settings['default_cors_url'] + 'http://travelplanner.mobiliteit.lu/restproxy/departureBoard?accessId=cdt&duration=1439&maxJourneys='+transportobject.results+'&format=json&id=A=1@O='+transportobject.station;
+		dataURL = _CORS_PATH + 'http://travelplanner.mobiliteit.lu/restproxy/departureBoard?accessId=cdt&duration=1439&maxJourneys='+transportobject.results+'&format=json&id=A=1@O='+transportobject.station;
 	}
 	else if(provider == '9292' || provider == '9292-train' || provider == '9292-bus' || provider == '9292-metro' || provider == '9292-tram-bus'){
-		dataURL = settings['default_cors_url'] + 'http://api.9292.nl/0.1/locations/'+transportobject.station+'/departure-times?lang=nl-NL';
+		dataURL = _CORS_PATH + 'http://api.9292.nl/0.1/locations/'+transportobject.station+'/departure-times?lang=nl-NL';
 	}
 	else if(provider == 'irailbe'){
 		var date = new Date($.now());

--- a/js/settings.js
+++ b/js/settings.js
@@ -468,6 +468,7 @@ settingList['about']['about_text4'] = {};
 settingList['about']['about_text4']['title'] = 'If you have any issues you can report them in our community thread <a href="https://www.domoticz.com/forum/viewtopic.php?f=67&t=17427" target="_blank">Bug report</a>.'
 
 var settings = {};
+var _CORS_PATH = '';
 doneSettings = false;
 if (typeof(Storage) !== "undefined") {
     $.each(localStorage, function (key, value) {
@@ -499,7 +500,6 @@ if (typeof(settings['pass_word']) === 'undefined') settings['pass_word'] = '';
 if (typeof(settings['app_title']) === 'undefined') settings['app_title'] = 'Dashticz';
 if (typeof(settings['domoticz_refresh']) === 'undefined') settings['domoticz_refresh'] = 5;
 if (typeof(settings['dashticz_refresh']) === 'undefined') settings['dashticz_refresh'] = 60;
-if (typeof(settings['default_cors_url']) === 'undefined') settings['default_cors_url'] = 'https://cors-anywhere.herokuapp.com/';
 if (typeof(settings['dashticz_php_path']) === 'undefined') settings['dashticz_php_path'] = './vendor/dashticz/';
 if (typeof(settings['wu_api']) === 'undefined') settings['wu_api'] = '';
 if (typeof(settings['wu_country']) === 'undefined') settings['wu_country'] = 'NL';
@@ -597,6 +597,7 @@ var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';
 
 var phpversion = '<br>PHP not installed!!';
+var _PHP_INSTALLED = false;
 
 $.ajax({
     url: settings['dashticz_php_path']+'info.php?get=phpversion',
@@ -604,8 +605,25 @@ $.ajax({
     dataType: 'json',
     success: function (data) {
         phpversion = '<br> PHP version: ' + data;
-                }
+        _PHP_INSTALLED = true;
+      },
+    error: function () {
+      console.log('PHP not installed.');
+    }
 });
+
+if (typeof(settings['default_cors_url'])==='undefined') {
+  if(_PHP_INSTALLED)
+    _CORS_PATH = settings['dashticz_php_path']+'cors.php?'
+  else {
+    _CORS_PATH = 'https://cors-anywhere.herokuapp.com/';
+    console.log('PHP not enabled and default_cors_url not set.');
+    console.log('CORS proxy: ' + _CORS_PATH);
+  }
+//    _CORS_PATH = 'http://192.168.178.18:8081/';
+}
+else
+  _CORS_PATH = settings['default_cors_url'];
 
 settingList['about']['about_text5'] = {};
 settingList['about']['about_text5']['title'] = domoversion + dzVents + python + phpversion;

--- a/js/traffic.js
+++ b/js/traffic.js
@@ -1,6 +1,6 @@
 function getTraffic() {
 
-    var rssurl = settings['default_cors_url'] + 'http://www.vid.nl/VI/_rss';
+    var rssurl = _CORS_PATH + 'http://www.vid.nl/VI/_rss';
 
     $.ajax(rssurl, {
         accepts: {

--- a/js/tvguide.js
+++ b/js/tvguide.js
@@ -4,7 +4,7 @@ var allchannels = [];
 function addTVGuide(tvobject, tvObjorg) {
     if (typeof(allchannels[1]) === 'undefined') {
         var cache = new Date().getTime();
-        curUrl=settings['default_cors_url']+'https://www.tvgids.nl/json/lists/channels.php';
+        curUrl=_CORS_PATH+'https://www.tvgids.nl/json/lists/channels.php';
         $.getJSON(curUrl, function (channels, textstatus, jqXHR) {
             for (num in channels) {
                 allchannels[channels[num]['id']] = channels[num]['name'];
@@ -33,7 +33,7 @@ function addTVGuide2(tvobject, tvObjorg) {
 
         var cache = new Date().getTime();
 
-        curUrl=settings['default_cors_url']+'http://www.tvgids.nl/json/lists/programs.php?day=0&channels=' + tvObj.channels.join(',') + '&time=' + cache;
+        curUrl= _CORS_PATH +'http://www.tvgids.nl/json/lists/programs.php?day=0&channels=' + tvObj.channels.join(',') + '&time=' + cache;
         moment.locale(settings['calendarlanguage']);
         $.getJSON(curUrl, function (data, textstatus, jqXHR) {
 

--- a/js/weather.js
+++ b/js/weather.js
@@ -1,7 +1,7 @@
 function loadWeather(location, country) {
     var html = '';
     if (typeof(settings['wu_api']) !== 'undefined' && settings['wu_api'] !== '' && settings['wu_api'] !== 0) {
-        $.getJSON(settings['default_cors_url'] + 'https://api.wunderground.com/api/' + settings['wu_api'] + '/conditions/q/' + country + '/' + location + '.json', function (weather) {
+        $.getJSON(_CORS_PATH + 'https://api.wunderground.com/api/' + settings['wu_api'] + '/conditions/q/' + country + '/' + location + '.json', function (weather) {
 
             $('.containsweather').each(function () {
                 var curfull = $(this);
@@ -36,7 +36,7 @@ function loadWeatherFull(location, country) {
         $('div.containsweatherfull').html('<div class="weatherfull"><div class="col-xs-3 transbg"></div><div class="col-xs-3 transbg"></div><div class="col-xs-3 transbg"></div><div class="col-xs-3 transbg"></div></div>');
 
         var html = '';
-        $.getJSON(settings['default_cors_url'] + 'https://api.wunderground.com/api/' + settings['wu_api'] + '/forecast10day/q/' + country + '/' + location + '.json', function (currentforecast) {
+        $.getJSON(_CORS_PATH + 'https://api.wunderground.com/api/' + settings['wu_api'] + '/forecast10day/q/' + country + '/' + location + '.json', function (currentforecast) {
             $('.containsweatherfull').each(function () {
                 var curfull = $(this);
                 if (typeof(currentforecast.forecast) === 'undefined') {

--- a/vendor/dashticz/cors.php
+++ b/vendor/dashticz/cors.php
@@ -1,0 +1,5 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+echo file_get_contents($_SERVER["QUERY_STRING"]);
+exit();
+?>

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 {
-"version": "2.4.6",
+"version": "2.4.7",
 "branch": "beta",
-"last_changes": "Small change in garbage name mapping rules to support Dordrecht",
+"last_changes": "Addition of internal PHP based cors proxy",
 "changelog" : {
+            "2.4.6": "Small change in garbage name mapping rules to support Dordrecht",
             "2.4.5": "Fix for cross origin issues with php",
             "2.4.4": "Fix HVC garbage data",
             "2.4.3": "Use local garbage.php module",


### PR DESCRIPTION
A PHP based CORS proxy has been integrated.

In case config['default_cors_url'] is defined it will use it as CORS proxy.
In case PHP is not installed it falls back to the defined CORS proxy in config['default_cors_url'].
In case config['default_cors_url'] is not set, it will use cors-anywhere.herokuapp.com by default.

For normal use just remove the config['default_cors_url'] from your CONFIG.js and it should work.
