### PR TITLE
Custom size of popup windows

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -186,9 +186,11 @@
 	border-bottom: 0px !important;
 }
 
-.modal-body {
-    position: relative;
-    padding: 0px 0px 0px 0px;
+/*
+next css sets the default height of the frame popup
+*/
+.popupheight {
+	height: calc(95vh - 150px);
 }
 
 .modal-body .glyphicon {
@@ -196,7 +198,7 @@
 	cursor:help;
 }
 .modal-dialog-settings {
-	min-width: 50% !important;
+	width: 70%;
 	margin: 80px auto;
 }
 
@@ -245,8 +247,12 @@
 }
 
 .modal-dialog {
-    min-width: 80% !important;
-    margin: 80px auto;
+    min-width: 80%;
+}
+
+.modal-dialog-custom {
+	min-width: 10px;
+	width: 80%;
 }
 
 .material-switch > input[type="checkbox"] {
@@ -589,6 +595,30 @@ a.playlist {
 		white-space:nowrap
 }
 .graphpopup {overflow:hidden;}
+
+/*To change the default height of the graph popup adapt the height value*/
+.graphheight {
+	width: 100%;
+	height: calc(80vh - 200px);
+}
+
+/*To remove the close button of the graph popup:
+.graphclose {
+	display: none;
+}
+*/
+
+.graphwidth {
+	min-width: 30px;
+	width: 70vw;
+}
+
+/*To remove the close button of a popup frame:
+.frameclose {
+	display: none;
+}
+*/
+
 html,
 body {
 	height: 100%;
@@ -1115,9 +1145,6 @@ img.icon {
 
 }
 
-.modal-dialog {
-    min-width: 90% !important;
-}
 div.screen {
   -webkit-background-size: cover;
   -moz-background-size: cover;

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -121,9 +121,9 @@ function getGraphByIDX(idx) {
 function getButtonGraphs(device) {
     if ($('#opengraph' + device['idx']).length === 0) {
         var html = '<div class="modal fade opengraph' + device['idx'] + '" data-idx="' + device['idx'] + '" id="opengraph' + device['idx'] + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-        html += '<div class="modal-dialog">';
+        html += '<div class="modal-dialog graphwidth">';
         html += '<div class="modal-content">';
-        html += '<div class="modal-header">';
+        html += '<div class="modal-header graphclose">';
         html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
         html += '</div>';
         html += '<div class="modal-body block_graphpopup_' + device['idx'] + '">' + language.misc.loading;
@@ -186,7 +186,7 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
 
                 var html = '<div class="graph' + (popup ? 'popup' : '')  + '" id="graph' + idx + '">';
                 html += '<div class="transbg col-xs-12">';
-                html += title + '<br /><div style="margin-left:15px;">' + buttons + '</div><br /><div id="graphoutput' + idx + '"></div>';
+                html += title + '<br /><div style="margin-left:15px;">' + buttons + '</div><br /><div ' + (popup ? 'class="graphheight" ':'') +  'id="graphoutput' + idx + '"></div>';
                 html += '</div>';
                 html += '</div>';
 

--- a/js/main.js
+++ b/js/main.js
@@ -550,6 +550,46 @@ function playAudio(file) {
     }
 }
 
+function createModalDialog(dialogClass, dialogId, myFrame) {
+    var setWidth = false;
+    var setHeight = false;
+    var mySetUrl = 'data-popup';
+    if (typeof(myFrame.framewidth) !== 'undefined') {
+      mywidth = myFrame.framewidth;
+      setWidth = true;
+      if(typeof(mywidth)==='number')
+        mywidth = mywidth + 'px'; 
+    }
+    if (typeof(myFrame.frameheight) !== 'undefined'){
+      myheight = myFrame.frameheight;
+      setHeight = true;
+      if(typeof(myheight)==='number')
+        myheight = myheight + 'px'; 
+    }
+    var html = '<div class="modal fade ' + dialogClass  + '" id="' + dialogId + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
+
+    html += '<div class="modal-dialog modal-dialog-custom" style="' 
+    html += setWidth ? 'width: ' + mywidth + '; ' : '';
+    html += '" >';
+
+    html += '<div class="modal-content">';
+    html += '<div class="modal-header frameclose">';
+    html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
+    html += '</div>';
+    html += '<div class="modal-body modalframe">';
+    if(dialogClass==='openpopup') {
+      mySetUrl = 'src';
+    }
+    html += '<iframe class="popupheight" ' + mySetUrl + '="' + myFrame.url + '" width="100%" height="100%" frameborder="0" allowtransparency="true" style="'
+    html += setHeight ? 'height: ' + myheight + '; ' : '';
+    html += '" ></iframe> ';
+    html += '</div>';
+    html += '</div>';
+    html += '</div>';
+    html += '</div>';
+    return html;
+}
+
 function triggerStatus(idx, value, device) {
     try {
         eval('getStatus_' + idx + '(idx,value,device)');
@@ -576,19 +616,8 @@ function triggerStatus(idx, value, device) {
 		var random = getRandomInt(1, 100000);
 		$('.modal.openpopup,.modal-backdrop').remove();
 
-		var html = '<div class="modal fade openpopup" id="popup_' + random + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-		html += '<div class="modal-dialog">';
-		html += '<div class="modal-content">';
-		html += '<div class="modal-header">';
-		html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-		html += '</div>';
-		html += '<div class="modal-body">';
-		html += '<iframe src="' + blocks[idx]['openpopupOn']['url'] + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-		html += '</div>';
-		html += '</div>';
-		html += '</div>';
-		html += '</div>';
-		$('body').append(html);
+    $('body').append(createModalDialog('openpopup', 'popup_' + random,blocks[idx]['openpopupOn']));
+
 		$('#popup_' + random).modal('show');
 
 		if (typeof(blocks[idx]['openpopupOn']['auto_close']) !== 'undefined') {
@@ -617,19 +646,8 @@ function triggerStatus(idx, value, device) {
 		var random = getRandomInt(1, 100000);
 		$('.modal.openpopup,.modal-backdrop').remove();
 
-		var html = '<div class="modal fade openpopup" id="popup_' + random + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-		html += '<div class="modal-dialog">';
-		html += '<div class="modal-content">';
-		html += '<div class="modal-header">';
-		html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-		html += '</div>';
-		html += '<div class="modal-body">';
-		html += '<iframe src="' + blocks[idx]['openpopupOff']['url'] + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-		html += '</div>';
-		html += '</div>';
-		html += '</div>';
-		html += '</div>';
-		$('body').append(html);
+    $('body').append(createModalDialog('openpopup', 'popup_' + random, blocks[idx]['openpopupOff']));
+
 		$('#popup_' + random).modal('show');
 
 		if (typeof(blocks[idx]['openpopupOff']['auto_close']) !== 'undefined') {
@@ -665,19 +683,8 @@ function triggerChange(idx, value, device) {
             var random = getRandomInt(1, 100000);
             $('.modal.openpopup,.modal-backdrop').remove();
 
-            var html = '<div class="modal fade openpopup" id="popup_' + random + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-            html += '<div class="modal-dialog">';
-            html += '<div class="modal-content">';
-            html += '<div class="modal-header">';
-            html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-            html += '</div>';
-            html += '<div class="modal-body">';
-            html += '<iframe src="' + blocks[idx]['openpopup']['url'] + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-            html += '</div>';
-            html += '</div>';
-            html += '</div>';
-            html += '</div>';
-            $('body').append(html);
+            $('body').append(createModalDialog('openpopup', 'popup_' + random, blocks[idx]['openpopup']));
+
             $('#popup_' + random).modal('show');
 
             if (typeof(blocks[idx]['openpopup']['auto_close']) !== 'undefined') {
@@ -715,19 +722,8 @@ function loadMaps(b, map) {
     var random = getRandomInt(1, 100000);
 
     if (typeof(map.link) !== 'undefined') {
-        var html = '<div class="modal fade" id="trafficmap_frame_' + b + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-        html += '<div class="modal-dialog">';
-        html += '<div class="modal-content">';
-        html += '<div class="modal-header">';
-        html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-        html += '</div>';
-        html += '<div class="modal-body">';
-        html += '<iframe data-popup="' + map.link + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        $('body').append(html);
+      map['url'] = map.link;
+      $('body').append(createModalDialog('','trafficmap_frame_' + b, map));
     }
 
     var key = 'UNKNOWN';
@@ -750,20 +746,7 @@ function loadMaps(b, map) {
 function loadButton(b, button) {
     var random = getRandomInt(1, 100000);
     if ($('#button_' + b).length == 0) {
-        var html = '<div class="modal fade" id="button_' + b + '_' + random + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-        html += '<div class="modal-dialog">';
-        html += '<div class="modal-content">';
-        html += '<div class="modal-header">';
-        html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-        html += '</div>';
-        html += '<div class="modal-body">';
-        html += '<iframe data-popup="' + button.url + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        $('body').append(html);
-
+        $('body').append(createModalDialog('','button_' + b + '_' + random, button));
         if (button.log == true) {
             if (typeof(getLog) !== 'function') $.ajax({url: 'js/log.js', async: false, dataType: 'script'});
             $('#button_' + b + '_' + random + ' .modal-body').html('');
@@ -851,19 +834,7 @@ function loadImage(i, image) {
     }
 
     if ($('.imgblockopens' + i).length == 0 && typeof(image.url) !== 'undefined') {
-        var html = '<div class="modal fade imgblockopens' + i + '" id="' + i + '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
-        html += '<div class="modal-dialog">';
-        html += '<div class="modal-content">';
-        html += '<div class="modal-header">';
-        html += '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>';
-        html += '</div>';
-        html += '<div class="modal-body">';
-        html += '<iframe data-popup="' + image.url + '" width="100%" height="570" frameborder="0" allowtransparency="true"></iframe> ';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        html += '</div>';
-        $('body').append(html);
+        $('body').append(createModalDialog('imgblockopens' + i, i, image));
     }
 
     var key = 'UNKNOWN';


### PR DESCRIPTION
* Makes the default popup window size relative to the screensize.
* Add the feature to set custom size of popup windows for buttons.
* The close buttons can be removed.

To change the default size of the graph popup windows add the following style blocks to your custom.css:
`
.graphheight {
	height: 400px;
}

.graphwidth {
	width: 400px;
}
`

To remove the close button of the graph popup add the following block to custom.js:
`
.graphclose {
	display: none;
}
`
To remove the close button of the frame popup add the following block to custom.js:
`
.frameclose {
	display: none;
}
`

To set a specific width of the frame of a button add 'framewidth' and/or 'frameheight' setting to the block definition in CONFIG.js like:
` 
buttons.buienradar	= { key: 'buienradar', width:12, isimage:true, refresh:6000, image: 'http://api.buienradar.nl/image/1.0/RadarMapNL?w=256&h=256', url:'https://gadgets.buienradar.nl/gadget/zoommap/?lat=52.06022&lng=4.39288&overname=2&zoom=13&naam=2496hx&size=5&voor=1', framewidth:580, frameheight: 520};

You can do the same for a popup window, like:
`blocks[107]['openpopup'] = { url: 'http://www.nos.nl', auto_close : 500, frameheight:200};
`


`