### PR TITLE
Add config ability for graph blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /custom_3
 /index3.html
 /custom_2/CONFIG_DEFAULT.js
+/node_modules/

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -170,6 +170,8 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
         realrange = range;
         if (range === 'last') realrange = 'day';
 
+        var blocksConfig = typeof(blocks['graph_' + idx]) !== 'undefined' ? blocks['graph_' + idx] : null;
+
         $.ajax({
             url: settings['domoticz_ip'] + '/json.htm?username=' + usrEnc + '&password=' + pwdEnc + '&type=graph&sensor=' + sensor + '&idx=' + idx + '&range=' + realrange + '&time=' + new Date().getTime() + '&jsoncallback=?',
             type: 'GET', async: true, contentType: "application/json", dataType: 'jsonp',
@@ -179,13 +181,24 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
                     return;
                 }
                 var buttons = createButtons(idx, title, label, range, current, sensor, popup);
+                var baseTitle = title;
 
-                title = '<h4>' + title;
+                if (blocksConfig && typeof(blocksConfig['title']) !== 'undefined') {
+                    baseTitle = blocksConfig['title'];
+                }
+
+                title = '<h4>' + baseTitle;
                 if (typeof(current) !== 'undefined' && current !== 'undefined') title += ': <B class="graphcurrent' + idx + '">' + current + ' ' + label + '</B>';
                 title += '</h4>';
 
                 var html = '<div class="graph' + (popup ? 'popup' : '')  + '" id="graph' + idx + '">';
-                html += '<div class="transbg col-xs-12">';
+
+                var width = 12;
+                if(blocksConfig && typeof(blocksConfig['width']) !== 'undefined') {
+                    width = blocksConfig['width'];
+                }
+
+                html += '<div class="transbg col-xs-' + width + '">';
                 html += title + '<br /><div style="margin-left:15px;">' + buttons + '</div><br /><div ' + (popup ? 'class="graphheight" ':'') +  'id="graphoutput' + idx + '"></div>';
                 html += '</div>';
                 html += '</div>';

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -209,6 +209,10 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
                 $('.block_graph' + (popup ? 'popup' : '') + '_' + idx).html(html);
 
                 var graphProperties = getGraphProperties(data.result[0], label);
+                if (blocksConfig && typeof(blocksConfig['graphTypes']) !== 'undefined') {
+                    graphProperties.keys = blocksConfig['graphTypes'];
+                }
+
                 graphProperties.dateFormat = settings['shorttime'];
                 if (range === 'month' || range === 'year') {
                     graphProperties.dateFormat = settings['shortdate'];


### PR DESCRIPTION
I couldn't find anything about it in the code and in the WIKI.

So now you can do:
```
blocks['graph_idx'] = {
    title: 'Custom graph title',
    width: 6
};
```

**Note** Some graphs append additional values (like xx.xx kWh)
If people want an ability to configure this, please let me know. I can implement support for this

If this PR is approved, WIKI need to be updated

I also added node_modules/* in .gitignore, because git is complaining about directory not being commited
If you don't want this, please let me know, I will remove it