### PR TITLE
Don't apply width for popup graphs

### DIFF
--- a/js/graphs.js
+++ b/js/graphs.js
@@ -214,7 +214,7 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
                 var html = '<div class="graph' + (popup ? 'popup' : '')  + '" id="graph' + idx + '">';
 
                 var width = 12;
-                if(blocksConfig && typeof(blocksConfig['width']) !== 'undefined') {
+                if(blocksConfig && typeof(blocksConfig['width']) !== 'undefined' && !popup) {
                     width = blocksConfig['width'];
                 }
 


### PR DESCRIPTION
In extension of this PR https://github.com/Dashticz/dashticz_v2/pull/443

This also fixes https://github.com/Dashticz/dashticz_v2/issues/424
The graph configuration also applies for popups (except for width)