### PR TITLE
Fix for dimmer RGB devices.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2297,5 +2297,5 @@ function isRGBDeviceAndEnabled(device) {
     return (typeof(settings['no_rgb']) === 'undefined'
             || (typeof(settings['no_rgb']) !== 'undefined'
                 && parseFloat(settings['no_rgb']) === 0))
-        && (device['SubType'] === 'RGBW' || device['SubType'] === 'RGBWW');
+        && (device['SubType'] === 'RGBW' || device['SubType'] === 'RGBWW' || device['SubType'] === 'RGB');
 }


### PR DESCRIPTION
Add recognition of RGB dimmers.
Until now only RGBW and RGBWW dimmers are recognized.

The domoticz device subtype determines the type of the dimmer.

See: https://www.domoticz.com/forum/viewtopic.php?f=67&t=27299