### PR TITLE
Improvement for forcerefresh

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,10 +1,11 @@
 {
-"version": "2.5.10",
+"version": "2.5.11",
 "branch": "beta",
-"last_changes": "Added confirmation option for switches",
+"last_changes": "Improved forcerefresh",
 "changelog" : {
+            "2.5.10": "Added confirmation option for switches",
             "2.5.9": "Small fix for TwenteMilieu garbage pickup dates",
-			"2.5.8": "No caching of version.txt",
+			      "2.5.8": "No caching of version.txt",
             "2.5.7": "Improved flash behavior for changing block",
             "2.5.6": "Improved layout for blinds",
             "2.5.5": "Calendar recurrence improvement",        


### PR DESCRIPTION
forcerefresh is set to 1 or true:
     adds current time to an url as second parameter (for webcams)
     adds the timestamp as first parameter if there are no parameters yet
forcerefresh:2
     calls nocache.php and prevent caching by setting headers in php.
forcerefresh:3
    adds timestamp parameter to the end of the url

No need anymore for cheapwebcam parameter.

See #465 