### PR TITLE
Add graph bar option

### DIFF
--- a/js/graphs.js
+++ b/js/graphs.js
@@ -251,7 +251,18 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
                 });
 
                 if ($('#graphoutput' + idx).length > 0) {
-                    makeMorrisGraph(idx, graphProperties);
+                    var graphtype='line';
+                    if (blocksConfig && typeof(blocksConfig['graph']) !== 'undefined'){
+                        graphtype = blocksConfig.graph;
+                    }
+                    
+                    switch(graphtype) {
+                        case 'bar':
+                            makeMorrisGraphBar(idx, graphProperties);
+                            break;
+                        default:
+                            makeMorrisGraph(idx, graphProperties);
+                    }
                 }
             }
         });
@@ -267,6 +278,35 @@ function makeMorrisGraph(idx, graphProperties) {
         gridTextColor: '#fff',
         lineWidth: 2,
         xkey: ['d'],
+        ykeys: graphProperties.keys,
+        labels: graphProperties.labels,
+        xLabelFormat: function (x) { return moment(x.src.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat); },
+        lineColors: settings['lineColors'],
+        pointFillColors: ['none'],
+        pointSize: 3,
+        hideHover: 'auto',
+        resize: true,
+        hoverCallback: function (index, options, content, row) {
+            var datePoint = moment(row.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat);
+            var text = datePoint + ": ";
+            graphProperties.keys.forEach(function (element, index) {
+                text += (index > 0 ? ' / ' : '') + number_format(row[element], 2) + ' ' + graphProperties.labels[index];
+            });
+            return text;
+        }
+    });
+}
+
+function makeMorrisGraphBar(idx, graphProperties) {
+    Morris.Bar({
+        parseTime: false,
+        element: 'graphoutput' + idx,
+        data: graphProperties.data,
+        fillOpacity: 0.2,
+        gridTextColor: '#fff',
+        lineWidth: 2,
+        xkey: ['d'],
+        //ymin: 'auto',    
         ykeys: graphProperties.keys,
         labels: graphProperties.labels,
         xLabelFormat: function (x) { return moment(x.src.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat); },

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -306,7 +306,6 @@ function makeMorrisGraphBar(idx, graphProperties) {
         gridTextColor: '#fff',
         lineWidth: 2,
         xkey: ['d'],
-        //ymin: 'auto',    
         ykeys: graphProperties.keys,
         labels: graphProperties.labels,
         xLabelFormat: function (x) { return moment(x.src.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat); },

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -252,13 +252,33 @@ function showGraph(idx, title, label, range, current, forced, sensor, popup) {
 
                 if ($('#graphoutput' + idx).length > 0) {
                     var graphtype='line';
-                    if (blocksConfig && typeof(blocksConfig['graph']) !== 'undefined'){
-                        graphtype = blocksConfig.graph;
+                    graphProperties.pointFillColors= ['none'];
+                    graphProperties.pointSize=3;
+                    graphProperties.lineColors=settings['lineColors'];
+
+                    if (blocksConfig) {
+
+                        if (typeof(blocksConfig['graph']) !== 'undefined'){
+                            graphtype = blocksConfig.graph;
+                        }
+
+                        if(typeof(blocksConfig['pointFillColors']) !== 'undefined') {
+                            graphProperties.pointFillColors = blocksConfig['pointFillColors']
+                        }
+
+
+                        if(typeof(blocksConfig['pointSize']) !== 'undefined') {
+                            graphProperties.pointSize = blocksConfig['pointSize']
+                        }
+                        if(typeof(blocksConfig['lineColors']) !== 'undefined') {
+                            graphProperties.lineColors = blocksConfig['lineColors']
+                        }
+
                     }
-                    
+                        
                     switch(graphtype) {
                         case 'bar':
-                            makeMorrisGraphBar(idx, graphProperties);
+                            makeMorrisGraphBar(idx,  graphProperties);
                             break;
                         default:
                             makeMorrisGraph(idx, graphProperties);
@@ -281,9 +301,9 @@ function makeMorrisGraph(idx, graphProperties) {
         ykeys: graphProperties.keys,
         labels: graphProperties.labels,
         xLabelFormat: function (x) { return moment(x.src.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat); },
-        lineColors: settings['lineColors'],
-        pointFillColors: ['none'],
-        pointSize: 3,
+        lineColors: graphProperties.lineColors,
+        pointFillColors: graphProperties.pointFillColors,
+        pointSize: graphProperties.pointSize,
         hideHover: 'auto',
         resize: true,
         hoverCallback: function (index, options, content, row) {
@@ -309,9 +329,9 @@ function makeMorrisGraphBar(idx, graphProperties) {
         ykeys: graphProperties.keys,
         labels: graphProperties.labels,
         xLabelFormat: function (x) { return moment(x.src.d, 'YYYY-MM-DD HH:mm').locale(settings['calendarlanguage']).format(graphProperties.dateFormat); },
-        lineColors: settings['lineColors'],
-        pointFillColors: ['none'],
-        pointSize: 3,
+        lineColors: graphProperties.lineColors,
+        pointFillColors: graphProperties.pointFillColors,
+        pointSize: graphProperties.pointSize,
         hideHover: 'auto',
         resize: true,
         hoverCallback: function (index, options, content, row) {


### PR DESCRIPTION
Adds the possibility to show a bar graph instead of a line graph.

Usage:
Add the key 'type' with value 'bar' to a graph-block definition. Example:
blocks['graph_56'] = {
   graph: 'bar'
}